### PR TITLE
Fixed RCE on wireless-tools

### DIFF
--- a/ifconfig.js
+++ b/ifconfig.js
@@ -31,7 +31,7 @@ var child_process = require('child_process');
  *
  */
 var ifconfig = module.exports = {
-  exec: child_process.exec,
+  exec: child_process.execFile,
   status: status,
   down: down,
   up: up
@@ -188,11 +188,16 @@ function parse_status_interface(callback) {
  *
  */
 function status(interface, callback) {
+  var cmd = "";
   if (callback) {
-    this.exec('ifconfig ' + interface, parse_status_interface(callback));  
+    cmd = 'ifconfig ' + interface;
+    cmd = cmd.split(' ');
+    this.exec(cmd[0], cmd.slice(1), parse_status_interface(callback));  
   }
   else {
-    this.exec('ifconfig -a', parse_status(interface));  
+    cmd = 'ifconfig -a';
+    cmd = cmd.split(' ');
+    this.exec(cmd[0], cmd.slice(1), parse_status(interface));  
   }
 }
 
@@ -214,7 +219,9 @@ function status(interface, callback) {
  *
  */
 function down(interface, callback) {
-  return this.exec('ifconfig ' + interface + ' down', callback);
+  var cmd = 'ifconfig ' + interface + ' down';
+  cmd = cmd.split(' ');
+  return this.exec(cmd[0], cmd.slice(1), callback);
 }
 
 /**
@@ -241,9 +248,11 @@ function down(interface, callback) {
  *
  */
 function up(options, callback) {
-  return this.exec('ifconfig ' + options.interface +
-    ' ' + options.ipv4_address +
-    ' netmask ' + options.ipv4_subnet_mask +
-    ' broadcast ' + options.ipv4_broadcast +
-    ' up', callback);
+  var cmd = 'ifconfig ' + options.interface +
+  ' ' + options.ipv4_address +
+  ' netmask ' + options.ipv4_subnet_mask +
+  ' broadcast ' + options.ipv4_broadcast +
+  ' up', callback;
+  cmd = cmd.split(' ');
+  return this.exec(cmd[0], cmd.slice(1));
 }


### PR DESCRIPTION
### 📊 Metadata *

Command injection vulnerability 
#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-wireless-tools

### ⚙️ Description *

The wireless-tools module is vulnerable against RCE since command is crafted using user inputs not validated and then executed, leading to arbitrary command injection. The argument options can be controlled by users without any sanitization. It was using `exec()` function which is vulnerable to **Command Injection** if it accepts user input and it goes through any sanitization or escaping.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

The PoC given in the bounty was incorrect, here's the PoC:
Install the package and run the below code, you'll need to have a PDF to test:
```javascript
var hd = require('wireless-tools/ifconfig');
hd.status("t; touch HACKED; #", function(){});
```
A file named `HACKED` will be created in the current working directory.

![image](https://user-images.githubusercontent.com/16708391/92592109-b4d73e80-f2bc-11ea-895b-738f5d8469c1.png)


### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

![image](https://user-images.githubusercontent.com/16708391/92592289-f536bc80-f2bc-11ea-983b-4a8da93bedc4.png)


### 👍 User Acceptance Testing (UAT)

Only `execFile` is used, no breaking changes introduced.
